### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Geodesi
+version: 3.0
+organization: Geodesi
+product: Transformasjoner
+repo_types: [PublicClient]
+platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "transformasjoner"
+  tags:
+  - "public"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "referanserammer"
+  system: "transformasjon"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_transformasjoner"
+  title: "Security Champion transformasjoner"
+spec:
+  type: "security_champion"
+  parent: "geodesi_security_champions"
+  members:
+  - "keyos89"
+  children:
+  - "resource:transformasjoner"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "transformasjoner"
+  links:
+  - url: "https://github.com/kartverket/transformasjoner"
+    title: "transformasjoner på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_transformasjoner"
+  dependencyOf:
+  - "component:transformasjoner"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "referanserammer"
   system: "transformasjon"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_transformasjoner"
-  title: "Security Champion transformasjoner"
-spec:
-  type: "security_champion"
-  parent: "geodesi_security_champions"
-  members:
-  - "keyos89"
-  children:
-  - "resource:transformasjoner"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "transformasjoner"
-  links:
-  - url: "https://github.com/kartverket/transformasjoner"
-    title: "transformasjoner på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_transformasjoner"
-  dependencyOf:
-  - "component:transformasjoner"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Geodesi`
- `product: Transformasjoner`
- `repo_types: [PublicClient]`
- `platforms: [LOKALT]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.